### PR TITLE
Typo fixed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-# ✏️ Text Edit in Wonderland ✏️ 
+# ✏️ Text Edit in Wonderland ✏️
 
 
 <img src="alice_pig.jpg" alt="Alice with Pig" style="width: 200px;"/>
 
-The mini text editor for people who want to focus on learning Python packaging. This text editor lets you: 
+The mini text editor for people who want to focus on learning Python packaging. This text editor lets you:
 
-+ Count the number of words, sentences, and characters in a file 
++ Count the number of words, sentences, and characters in a file
 + Determine the [Colman-Liau readabilty index](https://readable.io/content/the-coleman-liau-index/)
-+ Replace a phrase or string with another phrase 
++ Replace a phrase or string with another phrase
 + Change spacing between sentences from single space period to double space/period and backwards
 
-and not much else. 
+and not much else.
 
 
 ## Installing
 
-These directions are for OSX/Linux-based systems. Windows will be slightly different. 
+These directions are for OSX/Linux-based systems. Windows will be slightly different.
 
 1. You'll need at least Python 3.5 to run Text Edit.
 2. `git clone https://gitlab.com/veekaybee/textedit.git`
-3. `cd textedit/textedit`
+3. `cd textedit`
 4. Run `pip install .`
-5. That's it! You're ready to use textedit. 
-6. If you encounter any issues, `export PYTHONPATH="${PYTHONPATH}:/texteditpath"` to your `~/.bashrc` or Windows equivalent. 
-7. Running tests: `python -m unittest discover` to test basic wordcount functionality. 
+5. That's it! You're ready to use textedit.
+6. If you encounter any issues, `export PYTHONPATH="${PYTHONPATH}:/texteditpath"` to your `~/.bashrc` or Windows equivalent.
+7. Running tests: `python -m unittest discover` to test basic wordcount functionality.
 
 ### Prerequisites
 
@@ -33,13 +33,13 @@ Python 3.5
 
 ### Using the Package API
 
-To import into your Python code: 
+To import into your Python code:
 
 `import textedit`
 
-You can run the code interactively: 
+You can run the code interactively:
 ```
-#Replace 
+#Replace
 
 python replace.py ../texts/alice.txt "Vicki" "Dora the Explorer"
 Old Wordcount ('Words:', 274)
@@ -60,7 +60,7 @@ mbp-vboykis:review vboykis$ python readability.py "../texts/alice.txt"
 ('Reading Grade Level of Text:', 7)
 ```
 
-Or, you can import it and use on a text file: 
+Or, you can import it and use on a text file:
 
 ```
 from review import readability  #import everything in the file named readability
@@ -100,10 +100,10 @@ print("\n")
 
 ## Deployment
 
-None! This is not a production-ready package. Install on your local machine and test it out and break things. 
+None! This is not a production-ready package. Install on your local machine and test it out and break things.
 
 ## Built With
-Love and Alice in Wonderland. 
+Love and Alice in Wonderland.
 
 ## Authors
 
@@ -114,6 +114,4 @@ Love and Alice in Wonderland.
 
 This is free and unencumbered software released into the public domain.
 
-Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means. No guarantees, batteries sold separately. 
-
-
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means. No guarantees, batteries sold separately.


### PR DESCRIPTION
Hey there in README file under ##installing headline,

"cd textedit" should be there instead of "cd textedit/textedit" as setup.py file is in textedit/ directory.
Otherwise throws "**Directory '.' is not installable. File 'setup.py' not found.**" error while running "pip install ." command.